### PR TITLE
Update engine-swaps for 1.44

### DIFF
--- a/engine-swaps.html
+++ b/engine-swaps.html
@@ -22,7 +22,7 @@
 <img src="img/gt7info-logo.svg" width="400"/><br>
 <a href="https://ddm999.github.io/gt7info/">Return to home</a><br>
 <h2 id="engine-swaps">Engine Swaps</h2>
-<b>Last updated for v1.43</b><br>
+<b>Last updated for v1.44</b><br>
 <br>
 List is sorted by source car name.<br>
 <br>
@@ -356,7 +356,7 @@ List is sorted by source car name.<br>
     <h4 style="display: inline-block;">LS7-BRZ</h3>&emsp;
         <small>Source car:<br>Subaru BRZ Drift Car '17</small><br>
     <ul>
-        <li>Nissan GT-R '17 - <b>New in v1.43!</b></li>
+        <li>Nissan GT-R '17 - v1.43</li>
         <li>Nissan Silvia Q's (S13) '88</li>
     </ul>
 </div>
@@ -382,7 +382,7 @@ List is sorted by source car name.<br>
         <small>Source car:<br>Toyota MR2 GT-S '97</small><br>
     <ul>
         <li>Toyota Corolla Levin 1600GT APEX (AE86) '83 - v1.42</li>
-        <li>Toyota Sprinter Trueno 1600GT APEX (AE86) '83 - <b>New in v1.43!</b></li>
+        <li>Toyota Sprinter Trueno 1600GT APEX (AE86) '83 - v1.43</li>
     </ul>
 </div>
 <div id="engine-swap-block">
@@ -392,17 +392,28 @@ List is sorted by source car name.<br>
         <li>Nissan SILVIA spec-R AERO (S15) '02</li>
         <li>Subaru BRZ S '21</li>
         <li>Toyota GR86 RZ '21</li>
-        <li>Toyota GR Corolla MORIZO Edition '22 - <b>New in v1.43!</b></li>
+        <li>Toyota GR Corolla MORIZO Edition '22 - v1.43</li>
         <li>Toyota GR Yaris RZ "High performance" '20</li>
         <li>Toyota GR Supra RZ '19 - v1.42</li>
-        <li>Toyota Supra 3.0GT Turbo A '88 - <b>New in v1.43!</b></li>
+        <li>Toyota Supra 3.0GT Turbo A '88 - v1.43</li>
     </ul>
 </div>
 <div id="engine-swap-block">
     <h4 style="display: inline-block;">K14C-Swift</h3>&emsp;
         <small>Source car:<br>Suzuki Swift Sport '17</small><br>
     <ul>
-        <li>Suzuki Jimny XC '18 - <b>New in v1.43!</b></li>
+        <li>Suzuki Jimny XC '18 - v1.43</li>
+    </ul>
+</div>
+<div id="engine-swap-block">
+    <h4 style="display: inline-block;">EVO-Final-Gr.B</h3>&emsp;
+        <small>Source car:<br>Mitsubishi Lancer Evolution Final Gr.B Rally Car</small><br>
+    <ul>
+        <li>Mitsubishi Lancer Evolution III GSR '95 - <b>New in v1.44!</b></li>
+        <li>Mitsubishi Lancer Evolution IV GSR '96 - <b>New in v1.44!</b></li>
+        <li>Mitsubishi Lancer Evolution V GSR '98 - <b>New in v1.44!</b></li>
+        <li>Mitsubishi Lancer Evolution VI GSR T.M. EDITION Special Color Package '99 - <b>New in v1.44!</b></li>
+        <li>Mitsubishi Lancer Evolution IX MR GSR '06 - <b>New in v1.44!</b></li>
     </ul>
 </div>
 


### PR DESCRIPTION
What it says on the tin. 
- changed the "last updated"
- removed the "new in v1.43!" for "v1.43" to match the style of the old ones
- added the new engine swaps introduced.
PS: thanks for the website, i've been using as a source for making sure I collect duplicates of all engine swap cars.