### PR TITLE
Fix progress bar to start at top instead of default right position

### DIFF
--- a/extended-level-calculator.html
+++ b/extended-level-calculator.html
@@ -40,7 +40,7 @@ Level 50 XP: <input id="lv50-xp" type="number" id="xp" min="0" max="9999999999"/
 <br>
 <svg width="50" height="50">
   <circle stroke="#b5b5b5" fill="transparent" stroke-width="2" r="23" cx="25" cy="25"></circle>
-  <circle id="next-level-circle" stroke="#f1346d" fill="transparent" stroke-width="2" stroke-dasharray="0 144.5" r="23" cx="25" cy="25" style="stroke-dashoffset: 0;"></circle>
+  <circle id="next-level-circle" stroke="#f1346d" fill="transparent" stroke-width="2" stroke-dasharray="0 144.5" r="23" cx="25" cy="25" style="stroke-dashoffset: 0;" transform="rotate(-90 25 25)"></circle>
 </svg>
 <span id="collector-level">Collector Level</span>
 <span id="current-level">1</span>


### PR DESCRIPTION
Fix progress bar for level to start at top (12 o'clock position) instead of default value of right (3 o'clock position).